### PR TITLE
Add support for symlinks when scanning.

### DIFF
--- a/scripts/lib/civitai.py
+++ b/scripts/lib/civitai.py
@@ -314,41 +314,41 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, skip_nsfw_
 
     base, ext = os.path.splitext(model_path)
     first_preview = base+".png"
-    sec_preview = base+".preview.png"
+    sec_preview = base+".preview%s.png"
+    preview_count = 0
     info_file = base + suffix + model.info_ext
 
-    # check preview image
-    if not os.path.isfile(sec_preview):
-        # need to download preview image
-        util.printD("Checking preview image for model: " + model_path)
-        # load model_info file
-        if os.path.isfile(info_file):
-            model_info = model.load_model_info(info_file)
-            if not model_info:
-                util.printD("Model Info is empty")
-                return
+    util.printD("Checking preview image for model: " + model_path)
+    # load model_info file
+    if os.path.isfile(info_file):
+        model_info = model.load_model_info(info_file)
+        if not model_info:
+            util.printD("Model Info is empty")
+            return
 
-            if "images" in model_info.keys():
-                if model_info["images"]:
-                    for img_dict in model_info["images"]:
-                        if "nsfw" in img_dict.keys():
-                            if img_dict["nsfw"]:
-                                util.printD("This image is NSFW")
-                                if skip_nsfw_preview:
-                                    util.printD("Skip NSFW image")
-                                    continue
-                        
-                        if "url" in img_dict.keys():
-                            img_url = img_dict["url"]
-                            if max_size_preview:
-                                # use max width
-                                if "width" in img_dict.keys():
-                                    if img_dict["width"]:
-                                        img_url = get_full_size_image_url(img_url, img_dict["width"])
+        if "images" in model_info.keys():
+            if model_info["images"]:
+                for img_dict in model_info["images"]:
+                    if "nsfw" in img_dict.keys():
+                        if img_dict["nsfw"]:
+                            util.printD("This image is NSFW")
+                            if skip_nsfw_preview:
+                                util.printD("Skip NSFW image")
+                                continue
 
-                            util.download_file(img_url, sec_preview)
-                            # we only need 1 preview image
-                            break
+                    if "url" in img_dict.keys():
+                        img_url = img_dict["url"]
+                        if max_size_preview:
+                            # use max width
+                            if "width" in img_dict.keys():
+                                if img_dict["width"]:
+                                    img_url = get_full_size_image_url(img_url, img_dict["width"])
+
+                        preview_name = (sec_preview % preview_count) if preview_count != 0 else (sec_preview % '')
+                        # check preview image
+                        if not os.path.isfile(preview_name):
+                            util.download_file(img_url, preview_name)
+                        preview_count += 1
 
 
 # check new version for a model by model path

--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -50,7 +50,7 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                         # write model info to file
                         model.write_model_info(info_file, model_info)
                         
-                        main_model_info = civitai.get_model_info_by_id(model_info['id'])
+                        main_model_info = civitai.get_model_info_by_id(model_info['modelId'])
                         if main_model_info is None:
                             output = "Failed to get main_model_info"
                             util.printD(output)
@@ -60,9 +60,11 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                         model.write_model_info(model_info_file, main_model_info)
                         
                         with open(md_info_file, 'w') as f:
-                            f.write(md(model_info['description']))
+                            if model_info['description']:
+                                f.write(md(model_info['description']))
                             f.write('\n\n---\n\n')
-                            f.write(md(main_model_info['description']))
+                            if main_model_info['description']:
+                                f.write(md(main_model_info['description']))
 
                     # set model_count
                     model_count = model_count+1

--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -30,7 +30,7 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                     model_info_file = base + civitai.suffix + '.main' + model.info_ext
                     md_info_file = base + civitai.suffix + '.md'
                     # check info file
-                    if not os.path.isfile(info_file):
+                    if not os.path.isfile(info_file) or not os.path.isfile(model_info_file):
                         util.printD("Creating model info for: " + filename)
                         # get model's sha256
                         hash = util.gen_file_sha256(item)

--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -18,7 +18,7 @@ def scan_model(max_size_preview, skip_nsfw_preview):
     # scan_log = ""
     for model_type, model_folder in model.folders.items():
         util.printD("Scanning path: " + model_folder)
-        for root, dirs, files in os.walk(model_folder):
+        for root, dirs, files in os.walk(model_folder, followlinks=True):
             for filename in files:
                 # check ext
                 item = os.path.join(root, filename)

--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -61,10 +61,10 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                         
                         with open(md_info_file, 'w') as f:
                             if model_info['description']:
-                                f.write(md(model_info['description']))
+                                f.write(md(str(model_info['description'].encode('utf-8'))))
                             f.write('\n\n---\n\n')
                             if main_model_info['description']:
-                                f.write(md(main_model_info['description']))
+                                f.write(md(str(main_model_info['description'].encode('utf-8'))))
 
                     # set model_count
                     model_count = model_count+1

--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -4,7 +4,7 @@ import os
 from . import util
 from . import model
 from . import civitai
-
+from markdownify import markdownify as md
 
 
 # scan model to generate SHA256, then use this SHA256 to get model info from civitai
@@ -27,6 +27,8 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                     # find a model
                     # get info file
                     info_file = base + civitai.suffix + model.info_ext
+                    model_info_file = base + civitai.suffix + '.main' + model.info_ext
+                    md_info_file = base + civitai.suffix + '.md'
                     # check info file
                     if not os.path.isfile(info_file):
                         util.printD("Creating model info for: " + filename)
@@ -47,6 +49,20 @@ def scan_model(max_size_preview, skip_nsfw_preview):
                         
                         # write model info to file
                         model.write_model_info(info_file, model_info)
+                        
+                        main_model_info = civitai.get_model_info_by_id(model_info['id'])
+                        if main_model_info is None:
+                            output = "Failed to get main_model_info"
+                            util.printD(output)
+                            return output+", check console log for detail"
+                        
+                        # write main model info to file
+                        model.write_model_info(model_info_file, main_model_info)
+                        
+                        with open(md_info_file, 'w') as f:
+                            f.write(md(model_info['description']))
+                            f.write('\n\n---\n\n')
+                            f.write(md(main_model_info['description']))
 
                     # set model_count
                     model_count = model_count+1


### PR DESCRIPTION
Add `followlinks=True` to the walk function, so that symlinks are followed correctly.