### PR TITLE
Add support for symlinks when scanning.

### DIFF
--- a/scripts/lib/model_action_civitai.py
+++ b/scripts/lib/model_action_civitai.py
@@ -18,7 +18,7 @@ def scan_model(max_size_preview, skip_nsfw_preview):
     # scan_log = ""
     for model_type, model_folder in model.folders.items():
         util.printD("Scanning path: " + model_folder)
-        for root, dirs, files in os.walk(model_folder):
+        for root, dirs, files in os.walk(model_folder, followlinks=True):
             for filename in files:
                 # check ext
                 item = os.path.join(root, filename)


### PR DESCRIPTION
Add followlinks=True to the walk function, so that symlinks are followed correctly.

On Windows, you can make proper symlinks using the `mklink` command, which is supported in A1111.
https://www.howtogeek.com/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/

I apologize for the last PR. I didn't realize the other commits I made were getting pulled in too.