### PR TITLE
Add Extra Networks information to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Civitai: [Civitai Url](https://civitai.com/models/16768/civitai-helper-sd-webui-
   - 🏷: Use this model's preview image's prompt
 * Above buttons support thumbnail mode of Extra Network
 * Option to always show additional buttons, to work with touchscreen.  
+* Works for all tabs of Extra Networks - Textual Inversion, HyperNetworks, Checkpoints and Loras
 
 
 # Install


### PR DESCRIPTION
Add information that informs users that the script will work for all Extra Networks tabs, as I was curious before downloading and had to check civitai_helper.js to be sure. Unfortunately I only speak English so cannot update the other language's ReadMe pages