### PR TITLE
Add Lycoris support

### DIFF
--- a/scripts/ch_lib/civitai.py
+++ b/scripts/ch_lib/civitai.py
@@ -23,6 +23,7 @@ model_type_dict = {
     "TextualInversion": "ti",
     "Hypernetwork": "hyper",
     "LORA": "lora",
+    "LoCon": "lora",
 }
 
 


### PR DESCRIPTION
Add support for the LoCon and LoHa types; for now, they cannot be downloaded.
e.g. [https://civitai.com/models/22867/ukiyo-e-style](https://civitai.com/models/22867/ukiyo-e-style)