### PR TITLE
Im parent data

### DIFF
--- a/scripts/ch_lib/civitai.py
+++ b/scripts/ch_lib/civitai.py
@@ -70,12 +70,25 @@ def get_model_info_by_hash(hash:str):
         util.printD("error, content from civitai is None")
         return
     
+    util.printD("Fetching Parent Model Information")
+    parent_model = get_model_info_by_id(content['modelId'])
+
+    # this is VERY un-safe, as CivitAI returns full HTML in this, and the
+    # version's, description, but we haven't been filtering it so far, so
+    # I guess we'll get to it later...
+    content['model']['description'] = parent_model['description']
+    content['model']['tags'] = parent_model['tags']
+    content['model']['allowNoCredit'] = parent_model['allowNoCredit']
+    content['model']['allowCommercialUse'] = parent_model['allowCommercialUse']
+    content['model']['allowDerivatives'] = parent_model['allowDerivatives']
+    content['model']['allowDifferentLicense'] = parent_model['allowDifferentLicense']
+
     return content
 
 
 
 def get_model_info_by_id(id:str) -> dict:
-    util.printD("Request model info from civitai")
+    util.printD("Request model info from civitai: "+str(id))
 
     if not id:
         util.printD("id is empty")

--- a/scripts/ch_lib/util.py
+++ b/scripts/ch_lib/util.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 import os
+import sys
 import io
 import hashlib
 import requests
@@ -16,7 +17,7 @@ proxies = None
 
 # print for debugging
 def printD(msg):
-    print(f"Civitai Helper: {msg}")
+    print(f"Civitai Helper: {msg}", file=sys.stderr)
 
 
 def read_chunks(file, size=io.DEFAULT_BUFFER_SIZE):


### PR DESCRIPTION
Just a simple change to store additional information about the parent "Model" from CivitAI.  This information seems relevant.

Related: 

#131 - wrt getting more information about parent, and 'tags'/'type'
#113 - wrt pulling the description (of note, the "triggers" are already stored in the 'trained words' and in the prompts of the sample images

Note: this does not change the UI.  Further changes would be needed to display to the user, this is just groundwork to get this information on user's computers until the UI is set up to do something with it.