### PR TITLE
correct path --data-dir

### DIFF
--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -3,11 +3,11 @@
 import os
 import json
 from . import util
-from modules import shared
+from modules import shared, paths_internal
 
 
 # this is the default root path
-root_path = os.getcwd()
+root_path = paths_internal.data_path
 
 # if command line arguement is used to change model folder, 
 # then model folder is in absolute path, not based on this root path anymore.


### PR DESCRIPTION
current work directory is not the root "data" directory
see `--data-dir` [ Command-Line-Arguments-and-Settings](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Command-Line-Arguments-and-Settings)

note currently there is a bug in webui <= [1.2.1](https://github.com/AUTOMATIC1111/stable-diffusion-webui/tree/89f9faa63388756314e8a1d96cf86bf5e0663045) that will ignore `--data-dir` if it is set via `COMMANDLINE_ARGS`
this bug should be fixed in 1.3.0+