### PR TITLE
Add support for LyCoris tab

### DIFF
--- a/javascript/civitai_helper.js
+++ b/javascript/civitai_helper.js
@@ -338,7 +338,7 @@ onUiLoaded(() => {
 
     // get all extra network tabs
     let tab_prefix_list = ["txt2img", "img2img"];
-    let model_type_list = ["textual_inversion", "hypernetworks", "checkpoints", "lora"];
+    let model_type_list = ["textual_inversion", "hypernetworks", "checkpoints", "lora", "lycoris"];
     let cardid_suffix = "cards";
 
     //get init py msg
@@ -432,7 +432,7 @@ onUiLoaded(() => {
             //get active extratab
             const active_extra_tab = Array.from(get_uiCurrentTabContent().querySelectorAll('.extra-network-cards,.extra-network-thumbs'))
                 .find(el => el.closest('.tabitem').style.display === 'block')
-                ?.id.match(/^(txt2img|img2img)_(.+)_cards$/)[2]
+                ?.id.match(/^(txt2img|img2img|tab_twoshot_mask)_(.+)_cards$/)[2]
 
                 
             console.log("found active tab: " + active_extra_tab);
@@ -449,6 +449,9 @@ onUiLoaded(() => {
                     break;
                 case "lora":
                     active_extra_tab_type = "lora";
+                    break;
+                case "lycoris":
+                    active_extra_tab_type = "lycoris";
                     break;
             }
 
@@ -487,10 +490,16 @@ onUiLoaded(() => {
                 extra_network_id = tab_prefix+"_"+js_model_type+"_"+cardid_suffix;
                 // console.log("searching extra_network_node: " + extra_network_id);
                 extra_network_node = gradioApp().getElementById(extra_network_id);
-                // check if extr network is under thumbnail mode
+                let lycoris_node = gradioApp().getElementById(tab_prefix+"_lycoris_"+cardid_suffix);
+                let is_lycoris = !!lycoris_node.offsetWidth;
+                if (is_lycoris) {
+                    extra_network_node = lycoris_node;
+                    model_type = "lycoris";
+                }
+                // check if extra network is under thumbnail mode
                 is_thumb_mode = false
                 if (extra_network_node) {
-                    if (extra_network_node.className == "extra-network-thumbs") {
+                    if (extra_network_node.className == "extra-network-thumbs" || extra_network_node.className == "extra-network-cards") {
                         console.log(extra_network_id + " is in thumbnail mode");
                         is_thumb_mode = true;
                         // if (!ch_show_btn_on_thumb) {continue;}

--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -17,6 +17,7 @@ folders = {
     "hyper": os.path.join(root_path, "models", "hypernetworks"),
     "ckp": os.path.join(root_path, "models", "Stable-diffusion"),
     "lora": os.path.join(root_path, "models", "Lora"),
+    "lycoris": os.path.join(root_path, "models", "LyCORIS"),
 }
 
 exts = (".bin", ".pt", ".safetensors", ".ckpt")


### PR DESCRIPTION
Many users including myself have [a1111-sd-webui-lycoris](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris.git) installed. This makes it compatible with that plugin and installation type.

I would recommend running it on a standard installation just to make sure it doesn't disturb anything, but I don't believe it does.

Since this was done out of my own need, I don't know if there is an existing issue for this. I hope that's ok?