### PR TITLE
fix downloading url

### DIFF
--- a/scripts/ch_lib/downloader.py
+++ b/scripts/ch_lib/downloader.py
@@ -32,6 +32,10 @@ def dl(url, folder, filename, filepath):
 
     # first request for header
     rh = requests.get(url, stream=True, verify=False, headers=util.def_headers, proxies=util.proxies)
+    if rh.status_code == 404:
+        util.printD("404. Trying VAE now.")
+        url += "?type=VAE"
+        rh = requests.get(url, stream=True, verify=False, headers=util.def_headers, proxies=util.proxies)
     # get file size
     total_size = 0
     total_size = int(rh.headers['Content-Length'])


### PR DESCRIPTION
Some models can only be downloaded with VAE.

e.g.
[https://civitai.com/models/6424/chilloutmix](https://civitai.com/models/6424/chilloutmix)

```
$ curl https://civitai.com/api/download/models/11745
Model file not found(base)

$ curl https://civitai.com/api/download/models/11745?type=VAE
https://civitai-delivery-worker-prod-...
```