### PR TITLE
Add check if the download is a failure

### DIFF
--- a/scripts/ch_lib/downloader.py
+++ b/scripts/ch_lib/downloader.py
@@ -108,8 +108,10 @@ def dl(url, folder, filename, filepath):
 
     print()
 
-    # rename file
-    os.rename(dl_file_path, file_path)
-    util.printD(f"File Downloaded to: {file_path}")
-    return file_path
+    if downloaded_size == total_size:
+        # rename file
+        os.rename(dl_file_path, file_path)
+        util.printD(f"File Downloaded to: {file_path}")
+        return file_path
 
+    return

--- a/scripts/ch_lib/downloader.py
+++ b/scripts/ch_lib/downloader.py
@@ -113,5 +113,8 @@ def dl(url, folder, filename, filepath):
         os.rename(dl_file_path, file_path)
         util.printD(f"File Downloaded to: {file_path}")
         return file_path
+    elif downloaded_size > total_size:
+        # remove temporary-file
+        os.remove(dl_file_path)
 
     return


### PR DESCRIPTION
Currently, for some reason, even if the server resets the connection and the transfer is interrupted, it is treated as normal completion.
Of course, a model that has fallen into this state cannot be used for real.
Therefore, it is necessary to make an error properly.

Looking at the source code, you can see that it works like this:
* He restarts the transfer from the middle if there is a temporary file in the middle of the download
* He treats the transfer as complete regardless of whether the transfer was successful or not.

This second work is terrible.

It would be good to detect an error and branch when it occurs, but I am a Python beginner.
Since I wanted to minimize the difference, I finally decided to check whether the transfer of the desired size had been completed.
As a result, if the connection is interrupted in the middle, the temporary file will be left and treated as a failure and retried when "3. Download Model" is selected again.

In addition, since I decided that a mechanical retry should be avoided, I will not add the retry.

Generally, a return that does not return a value is described as a "return None". But nowhere write that, so I dared to match them.