### PR TITLE
Add a statement to re-encode the filename

### DIFF
--- a/scripts/ch_lib/downloader.py
+++ b/scripts/ch_lib/downloader.py
@@ -46,6 +46,7 @@ def dl(url, folder, filename, filepath):
             # content of a CD: "attachment;filename=FileName.txt"
             # in case "" is in CD filename's start and end, need to strip them out
             filename = cd.split("=")[1].strip('"')
+            filename = filename.encode('iso8859-1').decode('utf-8')
             if not filename:
                 util.printD("Fail to get file name from Content-Disposition: " + cd)
                 return


### PR DESCRIPTION
This PR is not for a bug but a temporary fix for misbehaving servers.
I fixed the phenomenon that the downloaded file's name is garbled when the file name registered in Civitai contains multilingual characters (including Latin Diacritic characters).
This is caused by the server re-encoding the UTF-8 filenames in UTF-8 as if they were ISO8859-1 byte streams.
As a countermeasure, I performed the following.

- Encode the received file name as ISO8859-1 and decode back to UTF-8

Before fix:
![before fix](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/67709629/b173b828-1c71-45c5-bf90-7e23d43259b3)

After fix:
![after fix](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/67709629/71b35302-749c-46e3-839a-67e03d006240)

(Tested on macOS, Ubuntu, Windows11)