### PR TITLE
[Bug Fix #234]: "Skip NSFW" not working correctly. 

### DIFF
--- a/scripts/ch_lib/civitai.py
+++ b/scripts/ch_lib/civitai.py
@@ -310,6 +310,9 @@ def get_model_id_from_url(url:str) -> str:
     
     return id
 
+def should_skip(selected_level, current_level):
+    order = ["None", "Soft", "Mature", "X", "Do not Skip"]
+    return order.index(current_level) >= order.index(selected_level)
 
 # get preview image by model path
 # image will be saved to file, so no return
@@ -344,7 +347,8 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, skip_nsfw_
                         if "nsfw" in img_dict.keys():
                             if img_dict["nsfw"] != "None": 
                                 util.printD("This image is NSFW: " + str(img_dict["nsfw"]))
-                                if skip_nsfw_preview:
+                                current_nsfw = img_dict.get("nsfw", "None")
+                                if should_skip(skip_nsfw_preview, current_nsfw):
                                     util.printD("Skip NSFW image")
                                     continue
                         

--- a/scripts/ch_lib/civitai.py
+++ b/scripts/ch_lib/civitai.py
@@ -342,8 +342,8 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, skip_nsfw_
                 if model_info["images"]:
                     for img_dict in model_info["images"]:
                         if "nsfw" in img_dict.keys():
-                            if img_dict["nsfw"]:
-                                util.printD("This image is NSFW")
+                            if img_dict["nsfw"] != "None": 
+                                util.printD("This image is NSFW: " + str(img_dict["nsfw"]))
                                 if skip_nsfw_preview:
                                     util.printD("Skip NSFW image")
                                     continue

--- a/scripts/ch_lib/model_action_civitai.py
+++ b/scripts/ch_lib/model_action_civitai.py
@@ -64,6 +64,13 @@ def scan_model(scan_model_types, max_size_preview, skip_nsfw_preview):
                         
                         # use this sha256 to get model info from civitai
                         model_info = civitai.get_model_info_by_hash(hash)
+                        
+                        # query the model's creator
+                        if model_info != {}:
+                            modelId = model_info["modelId"]
+                            creator =  civitai.get_model_info_by_id(str(modelId))["creator"]["username"]
+                            model_info["model"]["creator"] = creator  
+
                         # delay 1 second for ti
                         if model_type == "ti":
                             util.printD("Delay 1 second for TI")

--- a/scripts/ch_lib/setting.py
+++ b/scripts/ch_lib/setting.py
@@ -12,7 +12,7 @@ path = os.path.join(scripts.basedir(), name)
 data = {
     "model":{
         "max_size_preview": True,
-        "skip_nsfw_preview": False
+        "skip_nsfw_preview": "Soft"
     },
     "general":{
         "open_url_with_js": True,

--- a/scripts/civitai_helper.py
+++ b/scripts/civitai_helper.py
@@ -108,7 +108,8 @@ def on_ui_tabs():
                 gr.Markdown("### Scan Models for Civitai")
                 with gr.Row():
                     max_size_preview_ckb = gr.Checkbox(label="Download Max Size Preview", value=max_size_preview, elem_id="ch_max_size_preview_ckb")
-                    skip_nsfw_preview_ckb = gr.Checkbox(label="Skip NSFW Preview Images", value=skip_nsfw_preview, elem_id="ch_skip_nsfw_preview_ckb")
+                    nsfw_level_choices = ["Soft", "Mature", "X", "Do not Skip"]
+                    skip_nsfw_preview_ckb = gr.Dropdown(label="Block NSFW Level Above", choices=nsfw_level_choices, value=skip_nsfw_preview, elem_id="ch_skip_nsfw_preview_ckb")
                     scan_model_types_ckbg = gr.CheckboxGroup(choices=model_types, label="Model Types", value=model_types)
 
                 # with gr.Row():


### PR DESCRIPTION
## Fixed #234 
Every image will have the nsfw key-vaule. And I check the code and the downloaded model info. The json key nsfw is string rather than the bool. 
```
"url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5dd7174e-a3ae-4929-83ee-8d80266e11b3/width=450/2406511.jpeg",
"nsfw": "None",
```
```
if "nsfw" in img_dict.keys():
    if img_dict["nsfw"]:
        util.printD("This image is NSFW")
        if skip_nsfw_preview:
            util.printD("Skip NSFW image")
            continue
```
And we can review this code if img_dict["nsfw"] means that if the json have a ["nsfw"] key, the following code will be executed, now that the program will get the ["nsfw"] as a string "None", so the program will be executed with this bug.

##   [Feature Enhance] Users can now select NSFW level for image previews
<img width="426" alt="image" src="https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/70808322/47515412-4054-4492-94a3-0ca3eb57f035">

