### PR TITLE
Added a crude translator for Civitai-Meta-Data

### DIFF
--- a/javascript/civitai_helper.js
+++ b/javascript/civitai_helper.js
@@ -1296,21 +1296,21 @@ function translate_civitai_metadata() {
 		xhr.send();
 		xhr.onload = function() {
 			if (xhr.status=="200") {
-				console.log(ressource, xhr.status, JSON.parse(xhr.response));
+				//console.log(ressource, xhr.status, JSON.parse(xhr.response));
 				var model_data=JSON.parse(xhr.response),
 					modelName=model_data.model.name,
 					modelHash=model_data.files[0].hashes['AutoV2'],
 					modelFileName=model_data.files[0].name;
 
 				if(ressource.type=="checkpoint") { model=" Model hash: "+modelHash.toLowerCase()+", Model: "+ modelName+ ', '; needToTranslate--;}
-				if(ressource.type=="lora") { loras+='<lora:'+modelFileName.replace('.safetensors','')+':'+ressource.weight+"> #"+modelHash.toLowerCase()+"# ";  needToTranslate--;}
+				if(ressource.type=="lora") { loras+='<lora:'+modelFileName.replace('.safetensors','')+':'+ressource.weight+">, #"+modelHash.toLowerCase()+"#\n ";  needToTranslate--;}
 				if(ressource.type=="embed") {
 					var keyword=modelFileName.replace('.safetensors','').replace('.pt','');
 					if (!prompt_area.value.includes(keyword)) { // if TI not already in prompt...
 						if (keyword.includes('bad') || keyword.includes('neg')){
-							neg_ti += ' '+keyword+' #'+modelHash.toLowerCase()+'#, ';
+							neg_ti += ' '+keyword+', #'+modelHash.toLowerCase()+"#\n ";
 						} else {
-							pos_ti+=' '+keyword+' #'+modelHash.toLowerCase()+'#, ';
+							pos_ti+=' '+keyword+', #'+modelHash.toLowerCase()+"#\n ";
 						}
 					}
 					needToTranslate--;
@@ -1327,8 +1327,8 @@ function translate_civitai_metadata() {
 
 					newPrompt+=model;
 					newPrompt+= "RNG: CPU, ";
-					newPrompt=newPrompt.substr(0, lastPositivePrompt) + " " + loras + " " + newPrompt.substr(lastPositivePrompt);
-					newPrompt=newPrompt.substr(0, lastPositivePrompt) + " " + pos_ti + " " + newPrompt.substr(lastPositivePrompt);
+					newPrompt=newPrompt.substr(0, lastPositivePrompt) + ", " + loras + " " + newPrompt.substr(lastPositivePrompt);
+					newPrompt=newPrompt.substr(0, lastPositivePrompt) + ", " + pos_ti + " " + newPrompt.substr(lastPositivePrompt);
 
 					fistNegativePrompt=newPrompt.search('Negative prompt:');
 					stepPosition=newPrompt.search('Steps:')-1;


### PR DESCRIPTION
The Civitai-Generator doesn't offer some Meta-Data used by A1111 in favor of it's own format.

For example: https://civitai.com/images/8010475 includes [{"type":"checkpoint","modelVersionId":290640},{"type":"lora","weight":1,"modelVersionId":349887},{"type":"embed","weight":1,"modelVersionId":5637}] but no usual "Model hash" or lora-prompts that A1111 and Forge rely upon.

![image](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/1910987/250a5f2a-1986-4ba9-a93d-770026396623)

Loading this picture into A1111 and using "Paste" results in an entirely different picture, missing lots of styles.

![image](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/1910987/9f8be486-dc87-4068-8c93-77dbb93e4ebc)

I added a little bit of Javascript that asks Civitai via XHR which models are hidden behind "modelVersionId" and tries to re-create the missing sources. You basically have to throw in the picture(a usual), hit a new button, an after this you hit paste:

![image](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/1910987/2686bb72-6bea-4e1e-a4e2-873f99bf7078)

This currently only works with pictures dropped into txt2img and img2img's prompt field - I couldn't get it to work in "Png-Info" so far, but independently  of that, the results are pretty close to the original style (I guess as close as differences in Hardware and Software-Versions allow):

![image](https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/assets/1910987/afd2d78b-31a7-4499-a384-5a7b094ae9ad)

