### PR TITLE
[Bug] no button in the latest SD webui release (the extension also is the latest version #297

### DIFF
--- a/javascript/civitai_helper.js
+++ b/javascript/civitai_helper.js
@@ -34,9 +34,9 @@ function extract_version(text) {
     let matches;
     // for forge
     if (text[0] == 'f')
-        matches = text.match(/v[0-9]\.[0-9]\.[0-9]/);
+        matches = text.match(/v\d+\.\d+\.\d+/);
     else
-        matches = text.match(/[0-9]\.[0-9]\.[0-9]/);
+        matches = text.match(/\d+\.\d+\.\d+/);    
 
     if (matches === null || matches.length == 0) {
         return null;


### PR DESCRIPTION
Modified regular expression for version to use numeric values, not single character numbers - allowing for versions like "10" not just single characters, fixing compatibility with version 1.10.0.