### PR TITLE
[codex] Fix Forge Classic neo compatibility

### DIFF
--- a/javascript/civitai_helper.js
+++ b/javascript/civitai_helper.js
@@ -411,10 +411,7 @@ async function remove_card(event, model_type, search_term){
             let refresh_btn_id = "";
             let refresh_btn = null;
 
-            //check sd version
-            let sd_version = ch_sd_version();
-            console.log(`sd version is: ${sd_version}`);
-            if (sd_version >= "1.8.0") {
+            if (ch_is_sd1_8_or_newer()) {
                 let js_model_type = convertModelTypeFromPyToJS(model_type);
                 if (!js_model_type){return;}
 
@@ -704,6 +701,10 @@ function ch_dl_model_new_version(event, model_path, version_id, download_url){
  * @returns {number} - 1: version1 is higher, -1: version2 is higher, 0: same version
  */
 function compareVersions(version1, version2) {
+  if (!version1 || !version2) {
+      return -1;
+  }
+
   const v1Parts = version1.split('.').map(Number);
   const v2Parts = version2.split('.').map(Number);
 
@@ -719,6 +720,35 @@ function compareVersions(version1, version2) {
   }
 
   return 0; // same version
+}
+
+function ch_has_sd1_8_extra_networks_layout() {
+    let tab_prefix_list = ["txt2img", "img2img"];
+    let model_type_list = ["textual_inversion", "hypernetworks", "checkpoints", "lora"];
+
+    for (const prefix of tab_prefix_list) {
+        for (const js_model_type of model_type_list) {
+            if (
+                gradioApp().getElementById(prefix + "_" + js_model_type + "_controls") &&
+                gradioApp().getElementById(prefix + "_" + js_model_type + "_cards")
+            ) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function ch_is_sd1_8_or_newer() {
+    let sd_version = ch_sd_version();
+    console.log(`sd version is: ${sd_version}`);
+
+    if (sd_version) {
+        return compareVersions(sd_version, "1.8.0") >= 0;
+    }
+
+    return ch_has_sd1_8_extra_networks_layout();
 }
 
 
@@ -1003,7 +1033,7 @@ onUiLoaded(() => {
                 }
 
                 //check if tab is active
-                if (extra_tab.style.display == "block"){
+                if (extra_tab.style.display == "block" || getComputedStyle(extra_tab).display != "none"){
                     active_extra_tab = extra_tab;
                     active_model_type = js_model_type;
                     break;
@@ -1163,9 +1193,7 @@ onUiLoaded(() => {
     //add refresh button to extra network's toolbar
 
     //from sd version 1.8.0, extra network's toolbar is fully rewrited. This extension need to re-write this part too.
-    let sd_version = ch_sd_version();
-    console.log(`sd version is: ${sd_version}`);
-    if (compareVersions(sd_version, "1.8.0") >= 0){
+    if (ch_is_sd1_8_or_newer()){
         console.log("get sd version v1.8.0+");
 
         for (let prefix of tab_prefix_list) {
@@ -1180,6 +1208,10 @@ onUiLoaded(() => {
 
                 //get toolbar
                 extra_toolbar = gradioApp().getElementById(toolbar_id);
+                if (!extra_toolbar) {
+                    console.log("can not find toolbar with id: " + toolbar_id);
+                    continue;
+                }
 
                 //get official refresh button
                 refresh_btn_id = prefix + "_" + js_model_type + "_extra_refresh";
@@ -1218,7 +1250,9 @@ onUiLoaded(() => {
                 //so here we modify it into 5 to add another refresh button for this addon
                 extra_toolbar.style.gridTemplateColumns = "minmax(0, auto) repeat(5, min-content)";
 
-                extra_toolbar.appendChild(ch_refresh);
+                if (!Array.from(extra_toolbar.children).some((x) => x.title == ch_refresh.title)) {
+                    extra_toolbar.appendChild(ch_refresh);
+                }
 
             }
 
@@ -1228,7 +1262,7 @@ onUiLoaded(() => {
         }
 
         //run it once
-        //update_card_for_civitai_with_sd1_8();
+        update_card_for_civitai_with_sd1_8();
 
     } else {
         for (let prefix of tab_prefix_list) {

--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -37,22 +37,48 @@ vae_suffix = ".vae"
 
 
 # get cusomter model path
+def _first_existing_dir(*values):
+    for value in values:
+        if not value:
+            continue
+
+        if isinstance(value, (list, tuple, set)):
+            result = _first_existing_dir(*value)
+            if result:
+                return result
+            continue
+
+        path = os.fspath(value)
+        if os.path.isdir(path):
+            return path
+
+
 def get_custom_model_folder():
     util.printD("Get Custom Model Folder")
 
     global folders
 
-    if shared.cmd_opts.embeddings_dir and os.path.isdir(shared.cmd_opts.embeddings_dir):
-        folders["ti"] = shared.cmd_opts.embeddings_dir
+    embeddings_dir = _first_existing_dir(getattr(shared.cmd_opts, "embeddings_dir", None))
+    if embeddings_dir:
+        folders["ti"] = embeddings_dir
 
-    if shared.cmd_opts.hypernetwork_dir and os.path.isdir(shared.cmd_opts.hypernetwork_dir):
-        folders["hyper"] = shared.cmd_opts.hypernetwork_dir
+    hypernetwork_dir = _first_existing_dir(getattr(shared.cmd_opts, "hypernetwork_dir", None))
+    if hypernetwork_dir:
+        folders["hyper"] = hypernetwork_dir
 
-    if shared.cmd_opts.ckpt_dir and os.path.isdir(shared.cmd_opts.ckpt_dir):
-        folders["ckp"] = shared.cmd_opts.ckpt_dir
+    ckpt_dir = _first_existing_dir(
+        getattr(shared.cmd_opts, "ckpt_dir", None),
+        getattr(shared.cmd_opts, "ckpt_dirs", None),
+    )
+    if ckpt_dir:
+        folders["ckp"] = ckpt_dir
 
-    if shared.cmd_opts.lora_dir and os.path.isdir(shared.cmd_opts.lora_dir):
-        folders["lora"] = shared.cmd_opts.lora_dir
+    lora_dir = _first_existing_dir(
+        getattr(shared.cmd_opts, "lora_dir", None),
+        getattr(shared.cmd_opts, "lora_dirs", None),
+    )
+    if lora_dir:
+        folders["lora"] = lora_dir
 
 
 


### PR DESCRIPTION
## Summary

This change restores Civitai Helper compatibility with the recent `neo` branch of `sd-webui-forge-classic` while preserving the existing behavior used by Automatic1111-compatible WebUIs and older Forge/reForge installations.

On Forge Classic `neo`, the extension tab can load, but the Civitai Helper controls on Extra Networks cards fail to initialize. Model-folder discovery can also fail during extension startup.

## Root cause

Forge Classic `neo` differs from the older WebUI API in two relevant areas:

1. Its footer exposes a non-semantic version such as `version: neo`. `ch_sd_version()` therefore returns `null`, and the existing `compareVersions(sd_version, "1.8.0")` call throws while initializing the UI callback.
2. Its command-line options do not always expose legacy attributes such as `hypernetwork_dir` and may expose plural directory collections such as `ckpt_dirs` and `lora_dirs` instead of only singular values. Direct attribute access can raise `AttributeError` or ignore the configured model folders.

## What this changes

- Makes model-folder discovery defensive and supports both singular and plural command-option directory values.
- Keeps semantic-version detection as the primary path, then feature-detects the modern Extra Networks layout when the WebUI version is unavailable or non-semantic.
- Reuses that layout detection when refreshing cards after model removal.
- Detects active Extra Networks tabs using computed display state, which works with the Gradio 4 layout used by Forge Classic `neo`.
- Guards missing toolbars, avoids duplicate Civitai Helper refresh buttons, and performs the initial card-button injection for the modern layout.

## User impact

For Forge Classic `neo` users, this restores:

- correct extension initialization;
- correct checkpoint and LoRA directory resolution;
- the Civitai Helper tab and its Python/JavaScript bridge;
- the four Civitai Helper actions on Extra Networks model cards;
- the green helper refresh button without duplicates.

The patch remains backward-compatible: WebUIs that provide a normal semantic version continue through the existing version-based path, and legacy singular command options remain preferred when present.

## Validation

Tested locally with the current `sd-webui-forge-classic` `neo` branch and Gradio 4.40.0:

- `node --check javascript/civitai_helper.js`
- `git diff --check origin/main...HEAD`
- Python import and model-folder discovery smoke test
- Verified resolved embeddings, checkpoint, and LoRA directories
- Launched Forge Classic through `webui-user.bat`
- Verified the Civitai Helper tab and hidden JS/Python bridge controls load
- Verified all 18 displayed LoRA cards receive all four helper actions
- Verified no duplicate helper refresh buttons and no Civitai Helper JavaScript errors
- Verified the Python `add_trigger_words` callback reads a local `.civitai.info` file correctly